### PR TITLE
rerender on time change

### DIFF
--- a/svelte-v3/app.svelte
+++ b/svelte-v3/app.svelte
@@ -5,8 +5,12 @@
   let gridWorld = new GridWorld(23, 9)
   let startId = gridWorld.toId(startCol, startRow)
 	let stepLimit = 0
+  let bfsResults
 	
-	$: bfsResults = breadthFirstSearch(gridWorld, startId, stepLimit)
+	$: {
+    bfsResults = breadthFirstSearch(gridWorld, startId, stepLimit)
+    bfsResults = bfsResults
+  }
 	
   function toggleWall(col, row) {
     gridWorld.toggleWall(col, row);


### PR DESCRIPTION
An alternative approach is keeping the definition of `bfsResults` as is and changing the `<input>` to include `on:input={() => bfsResults = bfsResults}`.

I believe this is because `breadthFirstSearch` returns an object, so the same `obj = obj` technique that you use on line (previously 13, now) 17. Perhaps a writable store would be the way to go here.